### PR TITLE
Add automation utilities and security helpers

### DIFF
--- a/root_mas/root_mas/tools/cron.py
+++ b/root_mas/root_mas/tools/cron.py
@@ -36,3 +36,15 @@ class CronScheduler:
         while True:
             self.scheduler.run_pending()
             time.sleep(1)
+
+
+def _heartbeat() -> None:
+    """Простая демонстрационная задача."""
+    logging.info("[cron] heartbeat")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    cron = CronScheduler()
+    cron.add_job(_heartbeat, 60)
+    cron.run_forever()

--- a/root_mas/root_mas/tools/instance_factory.py
+++ b/root_mas/root_mas/tools/instance_factory.py
@@ -12,9 +12,47 @@ import subprocess
 import yaml  # type: ignore
 from pathlib import Path
 from typing import Dict, Any
+from datetime import datetime
+
+from .security import get_secret
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def auto_deploy_instance(instance_type: str = "internal", env_vars: Dict[str, str] | None = None) -> str:
+    """Automatically deploy an instance and register it.
+
+    A unique instance name is generated based on the current UTC timestamp.
+    Missing environment variables are fetched via :func:`get_secret`.
+
+    Args:
+        instance_type: Either ``internal`` or ``client``.
+        env_vars: Optional base environment variables for the ``.env`` file.
+
+    Returns:
+        The name of the created instance.
+    """
+
+    instance_name = f"{instance_type}_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+    env = env_vars.copy() if env_vars else {}
+
+    for key in [
+        "OPENROUTER_API_KEY",
+        "YANDEX_API_KEY",
+        "YANDEX_FOLDER_ID",
+        "N8N_API_TOKEN",
+        "TELEGRAM_BOT_TOKEN",
+    ]:
+        if key not in env:
+            secret = get_secret(key)
+            if secret:
+                env[key] = secret
+
+    env.setdefault("MAS_ENDPOINT", f"http://localhost:8000/{instance_name}")
+
+    deploy_instance(f"deploy/{instance_type}", env, instance_name, instance_type)
+    return instance_name
 
 
 def deploy_instance(directory: str, env_vars: Dict[str, str], instance_name: str, instance_type: str = "internal") -> None:
@@ -36,12 +74,17 @@ def deploy_instance(directory: str, env_vars: Dict[str, str], instance_name: str
     subprocess.run(["docker", "compose", "up", "-d"], cwd=str(deploy_dir))
     # Регистрируем инстанс в config/instances.yaml
     inst_cfg_path = REPO_ROOT / "config" / "instances.yaml"
-    with inst_cfg_path.open("r", encoding="utf-8") as f:
-        inst_data = yaml.safe_load(f) or {}
+    if inst_cfg_path.exists():
+        with inst_cfg_path.open("r", encoding="utf-8") as f:
+            inst_data = yaml.safe_load(f) or {}
+    else:
+        inst_data = {}
     insts = inst_data.setdefault("instances", {})
     insts[instance_name] = {
         "type": instance_type,
         "endpoint": env_vars.get("MAS_ENDPOINT", ""),
+        "created_at": datetime.utcnow().isoformat() + "Z",
+        "status": "running",
     }
     with inst_cfg_path.open("w", encoding="utf-8") as f:
         yaml.safe_dump(inst_data, f, allow_unicode=True)


### PR DESCRIPTION
## Summary
- extend `instance_factory` with auto deployment helper and richer instance registration
- add CLI sample to `cron` scheduler for periodic jobs
- implement basic secret retrieval and prompt approval in `security`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68875d679bf88320b55a0b39dd91cb85