### PR TITLE
Add research validation workflow

### DIFF
--- a/tools/callback_matrix.py
+++ b/tools/callback_matrix.py
@@ -16,6 +16,7 @@ from .callbacks import (
     retry_with_higher_tier_callback,
     budget_guard_callback,
     outgoing_to_telegram,
+    research_validation_cycle,
 )
 
 
@@ -28,6 +29,7 @@ CALLBACK_MATRIX: Dict[str, Callable[..., None]] = {
     "RETRY_WITH_HIGHER_TIER": retry_with_higher_tier_callback,
     "BUDGET_GUARD": budget_guard_callback,
     "OUTGOING_TO_TELEGRAM": outgoing_to_telegram,
+    "RESEARCH_TASK": research_validation_cycle,
 }
 
 

--- a/tools/callbacks.py
+++ b/tools/callbacks.py
@@ -116,3 +116,16 @@ def outgoing_to_telegram(message: str) -> None:
         _telegram_sender(message)
     else:
         print(f"[TG] {message}")
+
+
+def research_validation_cycle(query: str) -> None:
+    """Выполнить цикл исследование → валидация."""
+
+    logging.info("[callback] research_validation_cycle: %s", query)
+    from .researcher import search_and_store
+
+    results = search_and_store(query)
+    if results:
+        print(f"[ResearchFlow] сохранено {len(results)} результатов по запросу '{query}'")
+    else:
+        print(f"[ResearchFlow] не удалось подтвердить источники для '{query}'")

--- a/tools/cron.py
+++ b/tools/cron.py
@@ -10,9 +10,13 @@ cron.py
 Для использования установите библиотеку schedule: `pip install schedule`.
 """
 
-from typing import Callable, Any
+from typing import Callable, Any, Dict, Optional
 import time
 import logging
+import json
+
+from .callback_matrix import handle_event
+from memory.redis_store import RedisStore
 
 try:
     import schedule  # type: ignore
@@ -21,14 +25,60 @@ except ImportError:
 
 
 class CronScheduler:
-    def __init__(self) -> None:
-        if schedule is None:
-            raise RuntimeError("Для работы CronScheduler требуется библиотека schedule. Установите её: pip install schedule")
-        self.scheduler = schedule
+    """Простой cron-планировщик с опциональным хранением задач в Redis."""
 
-    def add_job(self, func: Callable[[], Any], interval: int) -> None:
-        """Добавить задачу, запускаемую каждые `interval` секунд."""
-        self.scheduler.every(interval).seconds.do(func)
+    def __init__(self, store: Optional[RedisStore] = None) -> None:
+        if schedule is None:
+            raise RuntimeError(
+                "Для работы CronScheduler требуется библиотека schedule. Установите её: pip install schedule"
+            )
+        self.scheduler = schedule
+        self.store = store
+        self.jobs: Dict[str, Any] = {}
+        if self.store is not None:
+            self._restore_jobs()
+
+    def _restore_jobs(self) -> None:
+        """Восстановить сохранённые задачи из Redis."""
+        for key in self.store.keys("cron:*"):
+            raw = self.store.get(key)
+            if not raw:
+                continue
+            try:
+                data = json.loads(raw.decode() if isinstance(raw, bytes) else raw)
+                name = key.split("cron:", 1)[1]
+                event = data["event"]
+                interval = data["interval"]
+                args = data.get("args", [])
+                kwargs = data.get("kwargs", {})
+                job = self.scheduler.every(interval).seconds.do(
+                    handle_event, event, *args, **kwargs
+                )
+                self.jobs[name] = job
+                logging.info("[cron] восстановлена задача %s", name)
+            except Exception as exc:  # pragma: no cover - restore best effort
+                logging.warning("[cron] ошибка восстановления %s: %s", key, exc)
+
+    def add_job(self, name: str, event: str, interval: int, *args: Any, **kwargs: Any) -> None:
+        """Добавить задачу и сохранить её в Redis."""
+        job = self.scheduler.every(interval).seconds.do(handle_event, event, *args, **kwargs)
+        self.jobs[name] = job
+        if self.store is not None:
+            payload = json.dumps({"event": event, "interval": interval, "args": args, "kwargs": kwargs})
+            self.store.set(f"cron:{name}", payload, ttl=0)
+        logging.info("[cron] добавлена задача %s (%s сек)", name, interval)
+
+    def remove_job(self, name: str) -> None:
+        job = self.jobs.pop(name, None)
+        if job is not None:
+            self.scheduler.cancel_job(job)
+        if self.store is not None:
+            self.store.delete(f"cron:{name}")
+        logging.info("[cron] удалена задача %s", name)
+
+    def list_jobs(self) -> Dict[str, Any]:
+        """Вернуть словарь запланированных задач."""
+        return dict(self.jobs)
 
     def run_forever(self) -> None:
         """Запустить цикл выполнения задач."""
@@ -46,5 +96,5 @@ def _heartbeat() -> None:
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     cron = CronScheduler()
-    cron.add_job(_heartbeat, 60)
+    cron.add_job("heartbeat", "OUTGOING_TO_TELEGRAM", 60, "cron alive")
     cron.run_forever()

--- a/tools/fact_checker.py
+++ b/tools/fact_checker.py
@@ -10,6 +10,7 @@ fact_checker.py
 """
 
 from typing import List, Dict, Any
+import logging
 
 
 def validate_sources(sources: List[Dict[str, Any]]) -> bool:
@@ -36,3 +37,25 @@ def validate_sources(sources: List[Dict[str, Any]]) -> bool:
             if word in url.lower() or word in title.lower():
                 return False
     return True
+
+
+def check_facts(results: List[Dict[str, Any]]) -> bool:
+    """Проверить факты на основе сниппетов."""
+
+    snippets = [r.get("snippet", "") for r in results if r.get("snippet")]
+    if len(snippets) < 2:
+        logging.info("[FactChecker] недостаточно данных для кросс-проверки")
+        return False
+    return cross_reference(snippets)
+
+
+def cross_reference(snippets: List[str]) -> bool:
+    """Проверить совпадения фраз в нескольких источниках."""
+
+    seen = set()
+    for text in snippets:
+        key = text.strip().lower()[:50]
+        if key in seen:
+            return True
+        seen.add(key)
+    return False

--- a/tools/researcher.py
+++ b/tools/researcher.py
@@ -10,6 +10,11 @@ HTTP‑запроса к DuckDuckGo Instant Answer API.
 """
 
 from typing import List, Dict, Any
+import logging
+import json
+
+from memory.chroma_store import ChromaStore
+from .fact_checker import validate_sources
 
 try:
     import requests  # type: ignore
@@ -60,5 +65,34 @@ def web_search(query: str, max_results: int = 5) -> List[Dict[str, Any]]:
                 count += 1
         return results
     except Exception as exc:
-        print(f"[Researcher] Ошибка web‑поиска: {exc}")
+        logging.warning("[Researcher] Ошибка web‑поиска: %s", exc)
         return []
+
+
+def store_results(query: str, results: List[Dict[str, Any]], collection: str = "research_mem") -> None:
+    """Сохранить результаты в коллекции ChromaDB."""
+
+    if not results:
+        return
+    try:
+        store = ChromaStore()
+        ids = [res["url"] for res in results]
+        docs = [json.dumps(res, ensure_ascii=False) for res in results]
+        metadatas = [{"query": query}] * len(results)
+        store.add(collection, ids=ids, documents=docs, metadatas=metadatas)
+        logging.info("[Researcher] сохранено %d документов в %s", len(results), collection)
+    except Exception as exc:  # pragma: no cover - optional dependency
+        logging.warning("[Researcher] ошибка сохранения: %s", exc)
+
+
+def search_and_store(query: str, max_results: int = 5) -> List[Dict[str, Any]]:
+    """Выполнить поиск, проверить факты и сохранить результаты."""
+
+    results = web_search(query, max_results)
+    if not results:
+        return []
+    if not validate_sources(results):
+        logging.info("[Researcher] источники не прошли валидацию")
+        return []
+    store_results(query, results)
+    return results


### PR DESCRIPTION
## Summary
- extend `CronScheduler` to persist event-based jobs via Redis
- implement research helper to store validated search results
- update `Fact-Checker` with cross-reference logic
- add `research_validation_cycle` callback and map new `RESEARCH_TASK` event

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68877eefad548320826944f5b0244540