### PR TITLE
Enhance observability and security modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ psycopg2-binary
 chromadb
 schedule
 prometheus_client
+hvac
 gitpython

--- a/tools/observability.py
+++ b/tools/observability.py
@@ -9,10 +9,18 @@ observability.py
 """
 
 try:
-    from prometheus_client import Counter, Gauge, Histogram  # type: ignore
-except ImportError:
+    from prometheus_client import (
+        Counter,
+        Gauge,
+        Histogram,
+        start_http_server,
+    )  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
     # Если библиотека не установлена, определяем заглушки
     Counter = Gauge = Histogram = None  # type: ignore
+
+    def start_http_server(*_args: int, **_kwargs: int) -> None:  # type: ignore
+        print("[observability] prometheus_client not installed")
 
 # Пример базовых метрик
 if Counter and Histogram:
@@ -28,6 +36,14 @@ if Counter and Histogram:
     )
 
 
+def start_metrics_server(port: int = 8000) -> None:
+    """Start HTTP server that exposes Prometheus metrics."""
+
+    if start_http_server:
+        start_http_server(port)
+        print(f"[observability] Prometheus metrics available on port {port}")
+
+
 def record_tokens(agent: str, amount: int) -> None:
     """Добавить количество токенов в счётчик."""
     if Counter:
@@ -38,3 +54,4 @@ def observe_duration(agent: str, seconds: float) -> None:
     """Записать длительность выполнения задачи."""
     if Histogram:
         task_duration.labels(agent=agent).observe(seconds)
+

--- a/tools/security.py
+++ b/tools/security.py
@@ -13,13 +13,34 @@ import os
 from pathlib import Path
 import yaml  # type: ignore
 
+try:
+    import hvac  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    hvac = None  # type: ignore
+
+from .callbacks import outgoing_to_telegram
+
 
 def get_secret(key: str) -> Optional[str]:
-    """Получить секрет по ключу из хранилища или переменных окружения."""
+    """Получить секрет по ключу из Vault, env или локального файла."""
 
     # Сначала пробуем прочитать из переменных окружения
     if val := os.getenv(key):
         return val
+
+    # Если настроен Vault и установлен hvac, пробуем получить секрет оттуда
+    addr = os.getenv("VAULT_ADDR")
+    token = os.getenv("VAULT_TOKEN")
+    path = os.getenv("VAULT_PATH", "secret/data/mas")
+    if hvac is not None and addr and token:
+        try:
+            client = hvac.Client(url=addr, token=token)
+            result = client.secrets.kv.v2.read_secret_version(path=path)
+            data = result.get("data", {}).get("data", {})
+            if isinstance(data, dict) and key in data:
+                return data[key]
+        except Exception as exc:  # pragma: no cover - network errors
+            print(f"[Security] Vault error: {exc}")
 
     # Затем ищем файл ~/.mas_secrets.yaml, в котором могут храниться ключи
     secrets_file = Path.home() / ".mas_secrets.yaml"
@@ -37,8 +58,15 @@ def get_secret(key: str) -> Optional[str]:
 def approve_global_prompt_change(diff: str) -> bool:
     """Запросить у пользователя подтверждение на изменение глобального промпта."""
 
-    print("[Security] Требуется подтверждение изменения глобального промпта:")
-    print(diff)
+    message = (
+        "[Security] Требуется подтверждение изменения глобального промпта:\n" + diff
+    )
+    try:
+        outgoing_to_telegram(message)
+    except Exception:
+        pass
+
+    print(message)
     try:
         answer = input("Apply changes? [y/N]: ").strip().lower()
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- expose Prometheus metrics via new `start_metrics_server`
- integrate HashiCorp Vault lookup in `get_secret`
- send prompt change requests via Telegram
- add `hvac` dependency for Vault support

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887856ab7088320bdce01cc3fdd144c