### PR TITLE
Implement prompt builder & budget-aware model picker

### DIFF
--- a/tests/test_llm_selector.py
+++ b/tests/test_llm_selector.py
@@ -1,0 +1,26 @@
+import tools.llm_selector as ls
+from tools.budget_manager import BudgetManager
+
+
+def test_pick_config_downgrades_with_budget(monkeypatch):
+    data = {
+        "tiers": {
+            "cheap": [{"name": "c1"}],
+            "standard": [{"name": "s1"}],
+        }
+    }
+    monkeypatch.setattr(ls, "load_tiers", lambda config_path=None: data)
+    manager = BudgetManager(daily_limit=10, spent_today=9)
+    tier, model = ls.pick_config("standard", manager=manager)
+    assert tier == "cheap"
+    assert model["name"] == "c1"
+
+
+def test_pick_config_no_downgrade(monkeypatch):
+    data = {"tiers": {"cheap": [{"name": "c1"}], "standard": [{"name": "s1"}]}}
+    monkeypatch.setattr(ls, "load_tiers", lambda config_path=None: data)
+    manager = BudgetManager(daily_limit=10, spent_today=1)
+    tier, model = ls.pick_config("standard", manager=manager)
+    assert tier == "standard"
+    assert model["name"] == "s1"
+

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,0 +1,39 @@
+import subprocess
+from pathlib import Path
+import pytest
+
+import tools.prompt_builder as pb
+
+
+def test_update_prompt_creates_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(pb, "REPO_ROOT", tmp_path)
+    called = []
+    monkeypatch.setattr(pb, "git_commit", lambda paths, message: called.append((list(paths), message)))
+
+    pb.update_agent_prompt("demo", "hello")
+
+    file_path = tmp_path / "prompts" / "agents" / "demo" / "system.md"
+    assert file_path.read_text() == "hello\n"
+    assert called[0][0] == [str(file_path.relative_to(tmp_path))]
+    assert "demo" in called[0][1]
+
+
+def test_update_global_permission(monkeypatch, tmp_path):
+    monkeypatch.setattr(pb, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(pb, "git_commit", lambda *a, **k: None)
+
+    with pytest.raises(PermissionError):
+        pb.update_agent_prompt("global", "hi")
+
+    pb.update_agent_prompt("global", "hi", allow_global=True)
+    file_path = tmp_path / "prompts" / "global" / "system.md"
+    assert file_path.read_text() == "hi\n"
+
+
+def test_get_prompt_history(monkeypatch, tmp_path):
+    monkeypatch.setattr(pb, "REPO_ROOT", tmp_path)
+    def fake_run(cmd, cwd=None, capture_output=False, text=False):
+        return subprocess.CompletedProcess(cmd, 0, stdout="LOG", stderr="")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = pb.get_prompt_history("demo", limit=2)
+    assert result == "LOG"

--- a/tools/llm_selector.py
+++ b/tools/llm_selector.py
@@ -32,7 +32,9 @@ def load_tiers(config_path: str = "config/llm_tiers.yaml") -> Dict[str, Any]:
     return data
 
 
-def pick_config(tier: str, attempt: int = 0) -> Tuple[str, Dict[str, str]]:
+def pick_config(
+    tier: str, attempt: int = 0, manager: BudgetManager | None = None
+) -> Tuple[str, Dict[str, str]]:
     """Получить конфигурацию модели из указанного уровня.
 
     Args:
@@ -45,6 +47,10 @@ def pick_config(tier: str, attempt: int = 0) -> Tuple[str, Dict[str, str]]:
     Note:
         Если количество попыток превышает список моделей, возвращается последняя модель уровня.
     """
+    if manager is not None and manager.needs_downgrade() and tier != "cheap":
+        tier = previous_tier(tier)
+        logging.warning("Достигнут лимит бюджета; используем уровень %s", tier)
+
     data = load_tiers()
     tiers = data.get("tiers", {})
     models: List[Dict[str, str]] = tiers.get(tier, [])

--- a/tools/prompt_builder.py
+++ b/tools/prompt_builder.py
@@ -1,19 +1,24 @@
-"""
-prompt_builder.py
-=================
+"""Utilities for managing system prompts used by the agents.
 
-Модуль для работы агента Prompt‑Builder. Позволяет создавать новые
-системные промпты для агентов, проводить аудит существующих и
-сохранять изменения в системе управления версиями (git). Функция
-`create_agent_prompt` создаёт файл system.md для нового агента.
-`audit_prompt` показывает разницу между текущей версией файла и
-последним коммитом. Попытка редактировать глобальный промпт
-(`prompts/global/system.md`) приводит к PermissionError.
+The module is primarily used by the Prompt‑Builder agent.  It provides
+helpers for creating and updating prompt files under ``prompts/`` and
+keeps them under version control using git.  Direct modifications of the
+global prompt (``prompts/global/system.md``) are forbidden unless the
+caller explicitly allows it.
+
+Functions
+~~~~~~~~~
+``create_agent_prompt`` -- create a new system prompt for an agent.
+``update_agent_prompt`` -- update an existing prompt with optional global
+permission check.
+``audit_prompt`` -- show the diff between the working tree and HEAD.
+``get_prompt_history`` -- show git log for a prompt file.
 """
 
 import subprocess
 from pathlib import Path
 from typing import Iterable
+
 from .prompt_io import write_prompt, read_prompt
 
 
@@ -43,6 +48,31 @@ def create_agent_prompt(agent_name: str, content: str) -> None:
     git_commit([str(path.relative_to(REPO_ROOT))], f"Add system prompt for agent {agent_name}")
 
 
+def update_agent_prompt(agent_name: str, content: str, *, allow_global: bool = False) -> None:
+    """Update an existing system prompt and commit the change.
+
+    Parameters
+    ----------
+    agent_name:
+        Target agent. Use ``"global"`` for the global system prompt.
+    content:
+        New prompt text.
+    allow_global:
+        Explicitly allow editing of the global prompt.
+    """
+
+    if agent_name.lower() == "global" and not allow_global:
+        raise PermissionError("Редактирование глобального промпта запрещено.")
+
+    if agent_name.lower() == "global":
+        path = REPO_ROOT / "prompts" / "global" / "system.md"
+    else:
+        path = REPO_ROOT / "prompts" / "agents" / agent_name / "system.md"
+
+    write_prompt(str(path), [content])
+    git_commit([str(path.relative_to(REPO_ROOT))], f"Update system prompt for {agent_name}")
+
+
 def audit_prompt(agent_name: str) -> str:
     """Вернуть diff промпта с последним коммитом.
 
@@ -59,11 +89,28 @@ def audit_prompt(agent_name: str) -> str:
         target = path / "agents" / agent_name / "system.md"
     rel_path = target.relative_to(REPO_ROOT)
     # Используем git diff для сравнения последней версии с HEAD
-    result = subprocess.run([
-        "git",
-        "diff",
-        "HEAD",
-        "--",
-        str(rel_path),
-    ], cwd=REPO_ROOT, capture_output=True, text=True)
+    result = subprocess.run(
+        ["git", "diff", "HEAD", "--", str(rel_path)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def get_prompt_history(agent_name: str, limit: int = 5) -> str:
+    """Return git log output for a prompt file."""
+
+    path = REPO_ROOT / "prompts"
+    if agent_name.lower() == "global":
+        target = path / "global" / "system.md"
+    else:
+        target = path / "agents" / agent_name / "system.md"
+    rel_path = target.relative_to(REPO_ROOT)
+    result = subprocess.run(
+        ["git", "log", f"-n{limit}", "--", str(rel_path)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
     return result.stdout


### PR DESCRIPTION
## Summary
- extend prompt_builder utilities
- update llm_selector to respect BudgetManager
- add unit tests for prompt builder and llm selector

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688784bf33a083208ce9560618bcd8a3