### PR TITLE
Add Dockerfile and extend Makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3
+*.egg
+*.egg-info
+*.dist-info
+root_mas.zip
+root_mas_sprint1.zip
+root_mas_sprint2.zip
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+CMD ["python", "run.py", "--goal", "echo"]

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,25 @@
-.PHONY: install lint test run
+.PHONY: install flake8 mypy lint test docker-build deploy run
 
 install:
 	pip install -r requirements.txt
-	pip install pytest flake8
+	pip install pytest flake8 mypy
 
-lint:
-	flake8 . --ignore=E501
+flake8:
+	flake8 . --config=.flake8
+
+mypy:
+	mypy --ignore-missing-imports --explicit-package-bases .
+
+lint: flake8 mypy
 
 test:
 	pytest -q
+
+docker-build:
+	docker build -t mas-app .
+
+deploy:
+	docker compose -f compose.yml up -d
 
 run:
 	python run.py --goal "echo"


### PR DESCRIPTION
## Summary
- add Dockerfile for building MAS image
- ignore build artifacts in `.dockerignore`
- extend Makefile with lint, mypy, test, docker build and deploy targets

## Testing
- `pytest -q`
- `make flake8`
- `make mypy` *(fails: Library stubs not installed for "yaml" and other type errors)*
- `make test`
- `make docker-build` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887961d8da08320a7e013c0252af43a