### PR TITLE
Implement AutoGen Studio logging

### DIFF
--- a/tests/test_studio_logger.py
+++ b/tests/test_studio_logger.py
@@ -1,0 +1,44 @@
+import json
+from types import SimpleNamespace
+
+import tools.studio_logger as sl
+
+
+def test_log_interaction(monkeypatch, tmp_path):
+    path = tmp_path / "log.jsonl"
+    monkeypatch.setattr(sl, "LOG_PATH", path)
+    sl.log_interaction("a", ["b"], {"role": "user", "content": "hi"})
+    data = path.read_text().strip()
+    entry = json.loads(data)
+    assert entry["sender"] == "a"
+    assert entry["receivers"] == ["b"]
+    assert entry["message"]["content"] == "hi"
+
+
+def test_export_logs(monkeypatch, tmp_path):
+    src = tmp_path / "src.jsonl"
+    src.write_text("data")
+    monkeypatch.setattr(sl, "LOG_PATH", src)
+    dest = tmp_path / "dest.jsonl"
+    sl.export_logs(dest)
+    assert dest.read_text() == "data"
+
+
+def test_send_to_studio(monkeypatch, tmp_path):
+    src = tmp_path / "s.jsonl"
+    src.write_text("data")
+    monkeypatch.setattr(sl, "LOG_PATH", src)
+
+    called = {}
+
+    class FakeResp(SimpleNamespace):
+        def raise_for_status(self):
+            pass
+
+    def fake_post(url, files=None, timeout=10):
+        called["url"] = url
+        return FakeResp(status_code=200)
+
+    monkeypatch.setattr(sl, "requests", SimpleNamespace(post=fake_post))
+    assert sl.send_to_studio("http://x") is True
+    assert called["url"] == "http://x"

--- a/tools/groupchat_manager.py
+++ b/tools/groupchat_manager.py
@@ -30,6 +30,7 @@ except Exception:  # pragma: no cover - optional dependency
             pass
 
 from .callback_matrix import handle_event
+from .studio_logger import log_interaction
 
 
 class RootGroupChatManager(GroupChatManager):
@@ -64,6 +65,7 @@ class RootGroupChatManager(GroupChatManager):
             return
         self.groupchat.messages.append({"sender": sender, "message": message})
         receivers = self.routing.get(sender, [])
+        log_interaction(sender, receivers, message)
         for name in receivers:
             agent = self._agents.get(name)
             if agent is not None:

--- a/tools/studio_logger.py
+++ b/tools/studio_logger.py
@@ -1,0 +1,60 @@
+"""Logging helpers for AutoGen Studio integration.
+
+This module records chat messages in a JSON Lines file. The log can then
+be uploaded to AutoGen Studio to visualise the dialog graph.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    requests = None  # type: ignore
+
+# Default log file used by the helpers
+LOG_PATH = Path("logs") / "studio.jsonl"
+
+
+def log_interaction(sender: str, receivers: Iterable[str], message: dict) -> None:
+    """Append a chat message to the Studio log."""
+
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    entry = {"sender": sender, "receivers": list(receivers), "message": message}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def export_logs(dest: str | Path) -> Path:
+    """Copy the Studio log to ``dest`` and return the new path."""
+
+    dest_path = Path(dest)
+    dest_path.write_text(LOG_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+    return dest_path
+
+
+def send_to_studio(url: str, log_file: Path | None = None) -> bool:
+    """Send the Studio log file to the given URL.
+
+    Returns ``True`` on success, otherwise ``False``.
+    """
+
+    if requests is None:
+        raise RuntimeError("requests package is required for sending logs")
+
+    lf = log_file or LOG_PATH
+    try:
+        with lf.open("rb") as f:
+            response = requests.post(
+                url,
+                files={"file": (lf.name, f, "text/plain")},
+                timeout=10,
+            )
+        response.raise_for_status()
+        return True
+    except Exception as exc:  # pragma: no cover - network errors
+        print(f"[studio_logger] failed to send logs: {exc}")
+        return False


### PR DESCRIPTION
## Summary
- add new `studio_logger` helper for AutoGen Studio logs
- record chat messages via `log_interaction`
- basic export and upload functions
- test new logging helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68879949c3e08320a819671f0e326478