### PR TITLE
Implement MultiTool fallback API

### DIFF
--- a/agents/core_agents.py
+++ b/agents/core_agents.py
@@ -119,9 +119,9 @@ class MultiToolAgent(BaseAgent):
         super().__init__("multitool", model)
 
     def call_api(self, api_name: str, params: Dict[str, Any]) -> Any:
-        from tools.multitool import call_api
+        from tools.multitool import call
 
-        return call_api(api_name, params)
+        return call(api_name, params)
 
 
 @dataclass

--- a/tests/test_multitool.py
+++ b/tests/test_multitool.py
@@ -1,0 +1,40 @@
+import types
+
+import tools.multitool as mt
+
+
+class DummyResp:
+    def __init__(self, json_data=None, status=200):
+        self._json = json_data or {}
+        self.status_code = status
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("err")
+
+
+def test_call_success(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=0):
+        return DummyResp({"ok": True})
+
+    monkeypatch.setattr(mt.requests, "post", fake_post)
+    result = mt.call("demo", {"x": 1}, fallbacks={})
+    assert result["ok"] is True
+
+
+def test_call_with_fallback(monkeypatch):
+    calls = []
+
+    def fake_post(url, json=None, headers=None, timeout=0):
+        calls.append(url)
+        if url.endswith("/api/kimi_k2"):
+            return DummyResp(status=404)
+        return DummyResp({"alt": True})
+
+    monkeypatch.setattr(mt.requests, "post", fake_post)
+    result = mt.call("kimi_k2", {}, fallbacks={"kimi_k2": ["kimi_k1"]})
+    assert result["alt"] is True
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- extend `tools.multitool` with fallback mapping and `call` helper
- update `MultiToolAgent` to use the new helper
- add tests covering success and fallback logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68879de6e5d483208f784b5f70d7fc9d