### PR TITLE
Add Prometheus and Grafana monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Several demos under [`examples/`](examples) showcase common flows:
 
 Explore these scripts to understand how the helper modules in `tools/` are intended to work.
 
+## Observability
+
+Prometheus and Grafana services are included under
+`deploy/internal`. Run `docker compose up -d` in that directory and the
+metrics endpoint at `autogen:9000` will be scraped automatically.
+Refer to [`docs/observability.md`](docs/observability.md) for details
+on dashboards and alerting.
+
 ## Development notes
 
 * Many modules are placeholders and should be expanded during future sprints.

--- a/deploy/internal/compose.yml
+++ b/deploy/internal/compose.yml
@@ -19,6 +19,27 @@ services:
       - chroma
     restart: unless-stopped
 
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command: --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    depends_on:
+      - autogen
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
   n8n:
     image: n8nio/n8n:latest
     ports:
@@ -63,3 +84,4 @@ volumes:
   redis-data:
   pg-data:
   chroma-data:
+  grafana-data:

--- a/deploy/internal/prometheus.yml
+++ b/deploy/internal/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: mas
+    static_configs:
+      - targets: ['autogen:9000']

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,44 @@
+# Мониторинг и метрики
+
+Этот документ описывает базовую настройку Prometheus и Grafana для Root‑MAS.
+
+## Сбор метрик
+
+Модуль `tools/observability.py` запускает HTTP‑сервер на порту `9000` и
+экспортирует несколько метрик:
+
+- `mas_requests_total` – количество запросов к LLM;
+- `mas_tokens_total` – число использованных токенов;
+- `mas_errors_total` – число ошибок обработки;
+- `mas_task_seconds` – длительность выполнения задач;
+- `mas_response_seconds` – время ответа модели.
+
+Функции `record_request`, `record_tokens`, `record_error`,
+`observe_duration` и `observe_response_time` можно вызывать в агентах
+или коллбеках для учёта событий.
+
+## Docker Compose
+
+В директории [`deploy/internal`](../deploy/internal) добавлены сервисы
+Prometheus и Grafana. Файл `prometheus.yml` настроен на сбор метрик с
+контейнера `autogen`:
+
+```yaml
+scrape_configs:
+  - job_name: mas
+    static_configs:
+      - targets: ['autogen:9000']
+```
+
+Запустите сервисы:
+
+```bash
+cd deploy/internal
+docker compose up -d
+```
+
+Prometheus будет доступен на <http://localhost:9090>, а Grafana – на
+<http://localhost:3000>. Добавьте источник данных Prometheus в Grafana и
+создайте дашборд с графиками по токенам, количеству запросов и времени
+ответа. Для оповещений можно настроить alert‑rules в Prometheus или
+использовать стандартные возможности Grafana.

--- a/run.py
+++ b/run.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 
 from tools.logging_setup import configure_logging
+from tools.observability import start_metrics_server
 
 from config_loader import AgentsConfig, LlmTiers, load_dataclass
 
@@ -71,6 +72,7 @@ def start_groupchat(goal: str) -> None:
 def main() -> None:
     # Настроить логирование
     configure_logging()
+    start_metrics_server()
     parser = argparse.ArgumentParser(description="Запуск Root MAS GroupChat")
     parser.add_argument(
         "--goal",

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,22 @@
+import types
+
+import tools.observability as obs
+
+
+def test_start_metrics_server(monkeypatch):
+    called = {}
+
+    def fake_start(port):
+        called['port'] = port
+
+    monkeypatch.setattr(obs, 'start_http_server', fake_start)
+    obs.start_metrics_server(1234)
+    assert called['port'] == 1234
+
+
+def test_metric_functions():
+    obs.record_request('a')
+    obs.record_tokens('a', 2)
+    obs.record_error('a')
+    obs.observe_duration('a', 0.1)
+    obs.observe_response_time('a', 0.2)

--- a/tools/observability.py
+++ b/tools/observability.py
@@ -29,14 +29,29 @@ if Counter and Histogram:
         "Общее количество использованных токенов",
         ["agent"],
     )
+    requests_counter = Counter(
+        "mas_requests_total",
+        "Количество запросов к LLM",
+        ["agent"],
+    )
+    errors_counter = Counter(
+        "mas_errors_total",
+        "Количество ошибок при обработке запросов",
+        ["agent"],
+    )
     task_duration = Histogram(
         "mas_task_seconds",
         "Время выполнения задач",
         ["agent"],
     )
+    response_time = Histogram(
+        "mas_response_seconds",
+        "Время ответа LLM",
+        ["agent"],
+    )
 
 
-def start_metrics_server(port: int = 8000) -> None:
+def start_metrics_server(port: int = 9000) -> None:
     """Start HTTP server that exposes Prometheus metrics."""
 
     if start_http_server:
@@ -50,8 +65,26 @@ def record_tokens(agent: str, amount: int) -> None:
         tokens_counter.labels(agent=agent).inc(amount)
 
 
+def record_request(agent: str) -> None:
+    """Увеличить счётчик запросов."""
+    if Counter:
+        requests_counter.labels(agent=agent).inc()
+
+
+def record_error(agent: str) -> None:
+    """Увеличить счётчик ошибок."""
+    if Counter:
+        errors_counter.labels(agent=agent).inc()
+
+
 def observe_duration(agent: str, seconds: float) -> None:
     """Записать длительность выполнения задачи."""
     if Histogram:
         task_duration.labels(agent=agent).observe(seconds)
+
+
+def observe_response_time(agent: str, seconds: float) -> None:
+    """Записать время ответа LLM."""
+    if Histogram:
+        response_time.labels(agent=agent).observe(seconds)
 


### PR DESCRIPTION
## Summary
- expose monitoring metrics in `observability.py`
- start metrics server from `run.py`
- provide Prometheus and Grafana services in internal compose file
- document monitoring setup and add new docs
- add tests for observability helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68879e52af408320b17062755fe87286