### PR TITLE
Add repo validator module with tests

### DIFF
--- a/tests/test_repo_validator.py
+++ b/tests/test_repo_validator.py
@@ -1,0 +1,17 @@
+from tools import repo_validator as rv
+
+
+def test_validate_repo_success(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / "README.md").write_text("hi\n")
+    (repo / "compose.yml").write_text("version: '3'\n")
+    assert rv.validate_repository(repo)
+
+
+def test_validate_repo_missing_files(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    assert not rv.validate_repository(repo)

--- a/tools/repo_validator.py
+++ b/tools/repo_validator.py
@@ -1,0 +1,31 @@
+"""
+repo_validator.py
+=================
+
+Проверка корректности развернутых репозиториев. Используется Instance‑Factory и другими инструментами для валидации созданных проектов.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def is_git_repo(path: str | Path) -> bool:
+    """Return True if ``path`` looks like a git repository."""
+    p = Path(path)
+    return p.is_dir() and (p / ".git").exists()
+
+
+def validate_repository(path: str | Path) -> bool:
+    """Validate that ``path`` contains a deployable project."""
+    repo = Path(path)
+    if not is_git_repo(repo):
+        return False
+    readme = repo / "README.md"
+    compose1 = repo / "compose.yml"
+    compose2 = repo / "docker-compose.yml"
+    if not readme.exists():
+        return False
+    if not (compose1.exists() or compose2.exists()):
+        return False
+    return True


### PR DESCRIPTION
## Summary
- implement `repo_validator` to check deployed repositories
- test repository validation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68879dbf0fa883208b8969b4dc92fb5f