### PR TITLE
Integrate Vault secret retrieval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,8 @@ POSTGRES_PORT=5432
 POSTGRES_DB=mas
 POSTGRES_USER=mas
 POSTGRES_PASSWORD=maspass
+
+# Optional Vault configuration
+VAULT_ADDR=http://localhost:8200
+VAULT_TOKEN=
+VAULT_PATH=secret/data/mas

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Root-MAS provides a lightweight skeleton for building a multi‑agent system wit
    pip install -r requirements.txt
    ```
 
-2. **Configure environment variables.**  Copy `.env.example` to `.env` and fill in the API keys (`OPENROUTER_API_KEY`, `YANDEX_API_KEY`, `YANDEX_FOLDER_ID`, `N8N_API_TOKEN`, `TELEGRAM_BOT_TOKEN`).
+2. **Configure secrets.**  Store API keys in HashiCorp Vault and set `VAULT_ADDR`,
+   `VAULT_TOKEN` and optionally `VAULT_PATH` in your environment.  You may copy
+   `.env.example` to `.env` for non‑secret settings like service URLs.
 
 3. **Start supporting services.**  Launch the containers with Docker Compose.  For an internal instance run:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,7 +22,8 @@ python run.py --goal "echo"
 python examples/workflow_demo.py
 ```
 
-Скрипт создаст черновик workflow в n8n и активирует его при наличии `N8N_URL` и `N8N_API_KEY` в переменных окружения.
+Скрипт создаст черновик workflow в n8n и активирует его при наличии `N8N_URL`
+и ключа в Vault (`N8N_API_KEY`).
 
 ## Запрос web‑приложения через GPT‑Pilot
 

--- a/examples/workflow_demo.py
+++ b/examples/workflow_demo.py
@@ -1,5 +1,6 @@
 """Demo for generating and activating an n8n workflow."""
 import os
+from tools.security import get_secret
 
 from n8n_client import N8nClient
 
@@ -13,7 +14,7 @@ WORKFLOW_SPEC = {
 
 def main() -> None:
     base = os.getenv("N8N_URL", "http://localhost:5678")
-    key = os.getenv("N8N_API_KEY", "changeme")
+    key = get_secret("N8N_API_KEY") or "changeme"
     client = N8nClient(base, key)
     result = client.create_workflow(WORKFLOW_SPEC)
     print("create_workflow:", result)

--- a/memory/postgres_store.py
+++ b/memory/postgres_store.py
@@ -9,6 +9,7 @@ postgres_store.py
 
 from typing import Any, Iterable, Optional
 import os
+from tools.security import get_secret
 
 try:
     import psycopg2  # type: ignore
@@ -32,11 +33,11 @@ class PostgresStore:
             raise RuntimeError(
                 "Для работы PostgresStore требуется библиотека psycopg2. Установите её: pip install psycopg2-binary"
             )
-        self.host = host or os.getenv("POSTGRES_HOST", "localhost")
-        self.port = port or int(os.getenv("POSTGRES_PORT", "5432"))
-        self.dbname = dbname or os.getenv("POSTGRES_DB", "mas")
-        self.user = user or os.getenv("POSTGRES_USER", "mas")
-        self.password = password or os.getenv("POSTGRES_PASSWORD", "maspass")
+        self.host = host or get_secret("POSTGRES_HOST") or "localhost"
+        self.port = port or int(get_secret("POSTGRES_PORT") or os.getenv("POSTGRES_PORT", "5432"))
+        self.dbname = dbname or get_secret("POSTGRES_DB") or "mas"
+        self.user = user or get_secret("POSTGRES_USER") or "mas"
+        self.password = password or get_secret("POSTGRES_PASSWORD") or "maspass"
         self.conn = psycopg2.connect(
             host=self.host,
             port=self.port,

--- a/tools/gpt_pilot.py
+++ b/tools/gpt_pilot.py
@@ -10,6 +10,8 @@ gpt_pilot.py
 import os
 from typing import Dict, Any, Optional
 
+from .security import get_secret
+
 try:
     import requests  # type: ignore
 except ImportError:  # pragma: no cover - optional dependency
@@ -17,7 +19,7 @@ except ImportError:  # pragma: no cover - optional dependency
 
 
 BASE_URL = os.getenv("GPT_PILOT_URL", "http://localhost:8000")
-API_KEY = os.getenv("GPT_PILOT_API_KEY", "")
+API_KEY = get_secret("GPT_PILOT_API_KEY") or ""
 
 
 def _headers() -> Dict[str, str]:

--- a/tools/multitool.py
+++ b/tools/multitool.py
@@ -12,13 +12,15 @@ LLM (например, Kimi K2) для обработки запросов. В �
 from typing import Any, Dict
 import os
 
+from .security import get_secret
+
 try:
     import requests  # type: ignore
 except ImportError:  # pragma: no cover - optional dependency
     requests = None  # type: ignore
 
 BASE_URL = os.getenv("MULTITOOL_URL", "http://localhost:8080")
-API_KEY = os.getenv("MULTITOOL_API_KEY", "")
+API_KEY = get_secret("MULTITOOL_API_KEY") or ""
 
 
 def _headers() -> Dict[str, str]:

--- a/tools/n8n_client.py
+++ b/tools/n8n_client.py
@@ -11,6 +11,8 @@ n8n_client.py
 import os
 from typing import Dict, Any, Optional
 
+from .security import get_secret
+
 # В реальной реализации вам понадобятся requests или aiohttp
 try:
     import requests  # type: ignore
@@ -30,7 +32,7 @@ class N8NClient:
                 "Библиотека requests не установлена. Установите её для работы n8n_client."
             )
         self.base_url = (base_url or os.getenv("N8N_URL", "http://localhost:5678")).rstrip("/")
-        self.api_key = api_key or os.getenv("N8N_API_KEY", "")
+        self.api_key = api_key or get_secret("N8N_API_KEY") or ""
 
     def _headers(self) -> Dict[str, str]:
         return {
@@ -80,7 +82,7 @@ class N8NClient:
 if __name__ == "__main__":
     # Пример использования клиента
     base = os.getenv("N8N_URL", "http://localhost:5678")
-    key = os.getenv("N8N_API_KEY", "changeme")
+    key = get_secret("N8N_API_KEY") or "changeme"
     client = N8NClient(base, key)
     workflow = {
         "name": "Echo Workflow",

--- a/tools/telegram_voice.py
+++ b/tools/telegram_voice.py
@@ -14,6 +14,7 @@ telegram_voice.py
 """
 
 import os
+from .security import get_secret
 import logging
 from dataclasses import dataclass
 from typing import Optional, Dict, Any, Callable
@@ -54,9 +55,9 @@ def stt(file_path: str, api_key: str | None = None) -> str:
     except ImportError:
         raise RuntimeError("Для работы STT требуется библиотека requests. Установите её: pip install requests")
 
-    yandex_api_key = api_key or os.getenv("YA_SPEECHKIT_API_KEY")
+    yandex_api_key = api_key or get_secret("YA_SPEECHKIT_API_KEY")
     if not yandex_api_key:
-        logging.error("Не указан YA_SPEECHKIT_API_KEY в .env")
+        logging.error("Не указан YA_SPEECHKIT_API_KEY")
         return ""
 
     # Получить IAM‑токен (в production необходимо реализовать refresh)
@@ -92,9 +93,9 @@ def tts(text: str, api_key: str | None = None) -> bytes:
     except ImportError:
         raise RuntimeError("Для работы TTS требуется библиотека requests. Установите её: pip install requests")
 
-    yandex_api_key = api_key or os.getenv("YA_SPEECHKIT_API_KEY")
+    yandex_api_key = api_key or get_secret("YA_SPEECHKIT_API_KEY")
     if not yandex_api_key:
-        logging.error("Не указан YA_SPEECHKIT_API_KEY в .env")
+        logging.error("Не указан YA_SPEECHKIT_API_KEY")
         return b""
 
     iam_token = yandex_api_key
@@ -216,10 +217,10 @@ def run_telegram_bot(
 
 
 if __name__ == "__main__":
-    token = os.getenv("TELEGRAM_TOKEN")
-    ya_key = os.getenv("YA_SPEECHKIT_API_KEY")
+    token = get_secret("TELEGRAM_TOKEN")
+    ya_key = get_secret("YA_SPEECHKIT_API_KEY")
     if not token:
-        raise RuntimeError("Не указан TELEGRAM_TOKEN в переменных окружения")
+        raise RuntimeError("Не указан TELEGRAM_TOKEN")
     if not ya_key:
-        raise RuntimeError("Не указан YA_SPEECHKIT_API_KEY в переменных окружения")
+        raise RuntimeError("Не указан YA_SPEECHKIT_API_KEY")
     run_telegram_bot(token, SpeechKitClient(ya_key))

--- a/tools/wf_builder.py
+++ b/tools/wf_builder.py
@@ -11,6 +11,8 @@ wf_builder.py
 import os
 from typing import Dict, Any
 
+from .security import get_secret
+
 
 def generate_n8n_json(spec: str) -> Dict[str, Any]:
     """Сгенерировать JSON‑workflow из текстовой спецификации.
@@ -59,7 +61,7 @@ def create_workflow(spec: str, n8n_base_url: str | None = None, api_key: str | N
     from .n8n_client import N8NClient
 
     base_url = n8n_base_url or os.getenv("N8N_URL", "http://localhost:5678")
-    key = api_key or os.getenv("N8N_API_KEY", "")
+    key = api_key or get_secret("N8N_API_KEY") or ""
     workflow_json = generate_n8n_json(spec)
     client = N8NClient(base_url, key)
     result = client.create_workflow(workflow_json)


### PR DESCRIPTION
## Summary
- fetch API keys and passwords via `get_secret`
- document Vault usage in README and docs
- provide Vault settings in `.env.example`

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68879e81db2883209d5f5ce863de3a06