### PR TITLE
Set approval policy for prompts and deployment scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/prompts/global/ @AlexeyPevz
+/deploy/ @AlexeyPevz

--- a/.github/workflows/approval.yml
+++ b/.github/workflows/approval.yml
@@ -1,0 +1,23 @@
+name: approval-check
+
+on:
+  pull_request:
+    paths:
+      - 'prompts/global/**'
+      - 'deploy/**'
+
+jobs:
+  verify-signature:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check commit signature
+        run: |
+          STATUS=$(git log -1 --pretty=%G?)
+          if [ "$STATUS" = "N" ]; then
+            echo "Head commit is not signed. Please sign the commit or provide an external signature." >&2
+            exit 1
+          fi
+

--- a/README.md
+++ b/README.md
@@ -77,3 +77,9 @@ on dashboards and alerting.
 * Additional design documents are available in [`docs/`](docs). See
   [`docs/usage.md`](docs/usage.md) for usage examples and
   [`docs/api.md`](docs/api.md) for an overview of available modules.
+
+## Approval process for critical changes
+
+Changes to global prompts under `prompts/global` and all files in `deploy/`
+require explicit approval. Pull requests touching these paths must have a
+GPG-signed commit and must be reviewed by @AlexeyPevz before merging.


### PR DESCRIPTION
## Summary
- require PR review from `@AlexeyPevz` for `prompts/global` and `deploy`
- add workflow to check commit signatures when those paths change
- document the new approval flow in `README`

## Testing
- `pip install --break-system-packages -r requirements.txt`
- `pip install --break-system-packages pyyaml`
- `pip install --break-system-packages requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a02fd7948320b6d8b54a4643b399