### PR TITLE
Use run_system.py as Docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
-CMD ["python", "run.py", "--goal", "echo"]
+CMD ["python", "run_system.py"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -38,5 +38,5 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # By default run echo goal for health-check. Override with `-e MAS_GOAL="..."`.
 ENV MAS_GOAL="echo"
 
-ENTRYPOINT ["python", "run.py"]
+ENTRYPOINT ["python", "run_system.py"]
 CMD ["--goal", "$MAS_GOAL"]


### PR DESCRIPTION
## Summary
- Run `run_system.py` in development Dockerfile
- Run `run_system.py` in production Dockerfile

## Testing
- `pytest` *(fails: NameError: name 'retry_with_higher_tier' is not defined, AttributeError: 'str' object has no attribute 'open', AttributeError: 'coroutine' object...)*

------
https://chatgpt.com/codex/tasks/task_e_688ca53c68a48320a693b70dcc1947b6