### PR TITLE
feat: add config loader aggregator

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -83,6 +83,21 @@ class AgentProfile(BaseModel):
     description: str
     capabilities: List[str]
 
+# Загружаем конфигурацию системы и формируем профили агентов
+CONFIG = load_config()
+AGENTS_CONFIG = CONFIG.get("agents", {})
+AGENT_PROFILES = [
+    AgentProfile(
+        agent_id=name,
+        name=cfg.get("role", name),
+        role=cfg.get("role", ""),
+        avatar_url=cfg.get("avatar_url", ""),
+        description=cfg.get("description", ""),
+        capabilities=cfg.get("capabilities", []),
+    )
+    for name, cfg in AGENTS_CONFIG.items()
+]
+
 class MessageFlow(BaseModel):
     flow_id: str
     user_message: str
@@ -420,54 +435,9 @@ async def voice_chat(audio_file: bytes, user_id: str = "voice_user"):
         logger.error(f"❌ Ошибка voice chat: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
-
 # =============================================================================
 # CHAT API - для диалога с Communicator Agent
 # =============================================================================
-
-# Профили агентов (можно вынести в отдельный конфиг)
-AGENT_PROFILES = [
-    AgentProfile(
-        agent_id="communicator",
-        name="Коммуникатор",
-        role="Интерфейс пользователя",
-        avatar_url="/static/avatars/communicator.png",
-        description="Принимает сообщения пользователей и координирует ответы",
-        capabilities=["Обработка голоса", "Перевод", "Форматирование"]
-    ),
-    AgentProfile(
-        agent_id="meta_agent",
-        name="Мета-Агент",
-        role="Координатор команды",
-        avatar_url="/static/avatars/meta_agent.png", 
-        description="Анализирует задачи и распределяет их между специалистами",
-        capabilities=["Планирование", "Координация", "Принятие решений"]
-    ),
-    AgentProfile(
-        agent_id="data_analyst",
-        name="Аналитик Данных",
-        role="Специалист по данным",
-        avatar_url="/static/avatars/data_analyst.png",
-        description="Анализирует данные и создает инсайты",
-        capabilities=["Анализ данных", "Статистика", "Визуализация"]
-    ),
-    AgentProfile(
-        agent_id="researcher",
-        name="Исследователь",
-        role="Поиск информации",
-        avatar_url="/static/avatars/researcher.png",
-        description="Ищет и верифицирует информацию",
-        capabilities=["Веб-поиск", "Проверка фактов", "Исследования"]
-    ),
-    AgentProfile(
-        agent_id="creative_writer",
-        name="Креативщик",
-        role="Создание контента",
-        avatar_url="/static/avatars/creative_writer.png",
-        description="Создает креативный и привлекательный контент",
-        capabilities=["Копирайтинг", "Сторителлинг", "Креатив"]
-    )
-]
 
 @app.post("/api/v1/chat/message", response_model=ChatResponse)
 async def send_message_with_visualization(message: ChatMessage):

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -9,12 +9,13 @@ import yaml
 T = TypeVar("T")
 
 
-def _load_yaml(path: Path) -> Dict:
+def _load_yaml(path: Path | str) -> Dict:
+    path = Path(path)
     with path.open("r", encoding="utf-8") as f:
         return yaml.safe_load(f) or {}
 
 
-def load_dataclass(path: Path, cls: Type[T]) -> T:
+def load_dataclass(path: Path | str, cls: Type[T]) -> T:
     """Load a YAML file and populate the given dataclass type."""
 
     data = _load_yaml(path)
@@ -52,7 +53,7 @@ class AgentsConfig:
     agents: Dict[str, AgentDefinition] = field(default_factory=dict)
 
     @classmethod
-    def from_yaml(cls, path: Path) -> "AgentsConfig":
+    def from_yaml(cls, path: Path | str) -> "AgentsConfig":
         raw = _load_yaml(path).get("agents", {})
         agents = {}
         for name, cfg in raw.items():
@@ -62,3 +63,43 @@ class AgentsConfig:
             agents[name] = AgentDefinition(**cfg)
         return cls(agents=agents)
 
+
+def load_config(config_dir: Path | str | None = None) -> Dict[str, Dict]:
+    """Load core YAML configuration files into a single dictionary.
+
+    Parameters
+    ----------
+    config_dir: Path | str | None
+        Directory containing configuration YAML files. Defaults to the
+        directory of this module.
+
+    Returns
+    -------
+    Dict[str, Dict]
+        Aggregated configuration with keys for each YAML file found.
+    """
+    if config_dir is None:
+        config_dir = Path(__file__).resolve().parent
+    else:
+        config_dir = Path(config_dir)
+
+    files = {
+        "agents": "agents.yaml",
+        "llm_tiers": "llm_tiers.yaml",
+        "instances": "instances.yaml",
+        "pricing": "pricing.yaml",
+        "proactive_mode": "proactive_mode.yaml",
+    }
+
+    config: Dict[str, Dict] = {}
+    for key, filename in files.items():
+        path = config_dir / filename
+        try:
+            data = _load_yaml(path)
+        except FileNotFoundError:
+            data = {}
+        if key == "agents":
+            config[key] = data.get("agents", {})
+        else:
+            config[key] = data
+    return config

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -34,3 +34,15 @@ agents:
     assert cfg.agents["bob"].model == "gpt-4"
 
 
+def test_load_config(tmp_path):
+    # Create minimal configuration files
+    (tmp_path / "agents.yaml").write_text(
+        "agents:\n  test_agent:\n    role: tester\n"
+    )
+    (tmp_path / "llm_tiers.yaml").write_text("tiers:\n  cheap: []\n")
+
+    config = cl.load_config(tmp_path)
+    assert "test_agent" in config["agents"]
+    assert "llm_tiers" in config and "tiers" in config["llm_tiers"]
+
+


### PR DESCRIPTION
## Summary
- aggregate YAML config files into a single loader
- build agent profiles from config in API
- cover configuration loader with unit tests

## Testing
- `pytest tests/test_config_loader.py -q`
- `pytest -q` *(fails: NameError: name 'retry_with_higher_tier' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688ca53f42d083209fc4de059cf9c891