### PR TITLE
chore: remove unused imports from integration API

### DIFF
--- a/api/integration.py
+++ b/api/integration.py
@@ -2,8 +2,6 @@
 Интеграция API с существующей MAS системой
 """
 
-import os
-import asyncio
 import logging
 from typing import Optional
 


### PR DESCRIPTION
## Summary
- remove unused imports from API integration module

## Testing
- `flake8 --select=F401 api/integration.py`
- `make lint` *(fails: Found 118 errors in 23 files)*

------
https://chatgpt.com/codex/tasks/task_e_688ca541d7f083209414c8b6f27693ad